### PR TITLE
Fix date parsing code to always return valid format

### DIFF
--- a/index.js
+++ b/index.js
@@ -441,7 +441,7 @@ function tryParseDate(rawDate) {
   // y/m/d
   matches = rawDate.match(/^(9\d)\/([01]?\d)\/([0-3]?\d)$/)
   if (matches) {
-    return `19${matches[3]}-${matches[2].padStart(2, '0')}-${matches[1].padStart(2, '0')}`
+    return `19${matches[1]}-${matches[2].padStart(2, '0')}-${matches[3].padStart(2, '0')}`
   }
 
   // two-digit year after slash (e.g., `/93`)

--- a/lib/createCSV.js
+++ b/lib/createCSV.js
@@ -8,7 +8,7 @@ const path = require('path');
  * @returns {string} - The CSV string.
  */
 function toCSV(prefix, inputText) {
-    let csv = `speaker,text\n${inputText.replace(/\r/g, '')}`;
+    let csv = inputText.replace(/\r/g, '')
     csv = csv.replace(/<&>.*<\/&>/g, '');
     csv = csv.replace(/\n\n+/g,'');
     csv = csv.replace(/<\$([A-Y])>/gm, `"${prefix}$1",`);
@@ -19,6 +19,7 @@ function toCSV(prefix, inputText) {
     // console.log('CSV output:', csv);
     // const outputPath = path.join(__dirname, '../output.csv');
     // require('fs').writeFileSync(outputPath, csv, 'utf8');
+    csv = `speaker,text\n${csv}`;
     return csv;
 }
 


### PR DESCRIPTION
Raises if it can't parse, acceptable formats are:
- d/m/y and y/m/d, most of the dates are one of these, the rest are edge-case-y
- two-digit year after slash (e.g., `/93`)
    - returns `1993`
- just four-digit year (e.g., `1992`)
- hyphen-, comma- or ampersand-separated days then /M/Y (e.g., `19-22/7/93`, `8,9/7/94` or `11&14/6/93`)
    - returns the first day
- ampersand-separated d/m then /y (e.g., `24/7&2/10/92`)
    - returns the first day/month: `1992-07-24`
- m/y with possible question mark at the end (e.g., `9/93?`)
    - returns YYYY-MM, which is unpopular but valid ISO `1993-09`, ignore the question mark

This seems to parse all dates from the `.nt.json` files correctly